### PR TITLE
fixes yaml error with @ as first character

### DIFF
--- a/controllers/sliders/config_form.yaml
+++ b/controllers/sliders/config_form.yaml
@@ -6,7 +6,7 @@
 name: raviraj.rjsliders::lang.idslider.title
 
 # Model Form Field configuration
-form: @/plugins/raviraj/rjsliders/models/slider/fields.yaml
+form: ~/plugins/raviraj/rjsliders/models/slider/fields.yaml
 
 # Model Class name
 modelClass: Raviraj\Rjsliders\Models\Slider

--- a/controllers/sliders/config_list.yaml
+++ b/controllers/sliders/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 # Model List Column configuration
-list: @/plugins/raviraj/rjsliders/models/slider/columns.yaml
+list: ~/plugins/raviraj/rjsliders/models/slider/columns.yaml
 
 # Model Class name
 modelClass: Raviraj\Rjsliders\Models\Slider


### PR DESCRIPTION
This pull request fixes following error with newer versions of symfony/yaml library.

```
The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 9 (near "form: @/plugins/raviraj/rjsliders/models/slider/fields.yaml").
/*redacted*/vendor/symfony/yaml/Inline.php line 292
```
